### PR TITLE
feat: pages finished up to UPS-5055

### DIFF
--- a/src/mobile/feature-activities/context/ActivityContext.ts
+++ b/src/mobile/feature-activities/context/ActivityContext.ts
@@ -5,12 +5,12 @@ import { Search } from "@/shared/lib/dataAccess";
 
 // undefined: user has chosen to continue without selecting an activity
 // null: user hasn't selected an activity yet
-export type Activity = Search.EventAllOf | null | undefined;
+export type Activity = Search.EventAllOf | null;
 
 export const ActivityContext = createContext<{
   selectedActivity: Activity;
   setSelectedActivity: (activity: Activity) => void;
 }>({
-  selectedActivity: undefined,
+  selectedActivity: null,
   setSelectedActivity: () => {},
 });

--- a/src/mobile/feature-counter/components/CounterPage.tsx
+++ b/src/mobile/feature-counter/components/CounterPage.tsx
@@ -40,7 +40,7 @@ export const CounterPage = () => {
     setActiveCounter(organizer);
   };
 
-  useEffect(() => setSelectedActivity(null));
+  useEffect(() => setSelectedActivity(null), [setSelectedActivity]);
 
   useEffect(() => {
     const data = allData?.data || [];

--- a/src/mobile/feature-counter/components/CounterPage.tsx
+++ b/src/mobile/feature-counter/components/CounterPage.tsx
@@ -5,11 +5,13 @@ import { CounterNoData, CounterPicker } from "@/mobile/feature-counter";
 import { ChangeEvent, useEffect, useState } from "react";
 import { useCounter } from "@/shared/feature-counter/context/useCounter";
 import { UitpasLoading } from "@/mobile/lib/ui";
+import { useActivity } from "@/mobile/feature-activities/context/useActivity";
 
 export const CounterPage = () => {
   const { data: allData, isSuccess, isLoading } = useGetPermissions();
   const [searchString, setSearchString] = useState<string>("");
   const { setActiveCounter, lastCounterUsed } = useCounter();
+  const { setSelectedActivity } = useActivity();
 
   const dataWithoutLastCounter =
     allData?.data?.filter(
@@ -37,6 +39,8 @@ export const CounterPage = () => {
   const handleCounterClick = (organizer: Organizer) => () => {
     setActiveCounter(organizer);
   };
+
+  useEffect(() => setSelectedActivity(null));
 
   useEffect(() => {
     const data = allData?.data || [];

--- a/src/mobile/feature-identification/scan/components/BarcodeScanner.tsx
+++ b/src/mobile/feature-identification/scan/components/BarcodeScanner.tsx
@@ -25,6 +25,7 @@ export const BarcodeScanner = () => {
   const router = useRouter();
   const scannerRef = useRef<HTMLDivElement>();
   const [scannerReady, setScannerReady] = useState<boolean>(false);
+  const [torchSupported, setTorchSupported] = useState<boolean>(false);
   const [torchAvailable, setTorchAvailable] = useState<boolean>(false);
 
   const handleFlashToggle = () => {
@@ -108,14 +109,15 @@ export const BarcodeScanner = () => {
           Quagga.start();
           setScannerReady(true);
           setTorchAvailable(() => {
-            if (navigator.userAgent.includes("Firefox")) {
-              // Firefox doesn't support torch or getCapabilities()
-              return false;
-            } else {
+            try {
+              setTorchSupported(true);
               return (
                 Quagga.CameraAccess.getActiveTrack()?.getCapabilities().torch ??
                 false
               );
+            } catch (err) {
+              setTorchSupported(false);
+              return false;
             }
           });
         }
@@ -159,7 +161,7 @@ export const BarcodeScanner = () => {
         >
           <Close sx={{ fontSize: 30 }} />
         </IconButton>
-        {navigator.userAgent.includes("Firefox") ? null : (
+        {!torchSupported ? null : (
           <IconButton
             disableRipple
             disabled={!torchAvailable}
@@ -186,7 +188,7 @@ export const BarcodeScanner = () => {
             sx={(theme) => ({
               position: "absolute",
               color: theme.palette.neutral[0],
-              right: navigator.userAgent.includes("Firefox") ? "0%" : "15%",
+              right: !torchSupported ? "0%" : "15%",
               zIndex: 20,
             })}
             onClick={handleFlipCamera}

--- a/src/mobile/feature-identification/scan/components/BarcodeScanner.tsx
+++ b/src/mobile/feature-identification/scan/components/BarcodeScanner.tsx
@@ -47,7 +47,7 @@ export const BarcodeScanner = () => {
   };
 
   const handleValidScan = (code: string) => {
-    router.push(`/mobile/saving?code=${code}`);
+    router.push(`/mobile/saving?uitpas=${code}`);
   };
 
   const handleFlipCamera = () => {

--- a/src/mobile/feature-identification/scan/components/BarcodeScanner.tsx
+++ b/src/mobile/feature-identification/scan/components/BarcodeScanner.tsx
@@ -26,9 +26,6 @@ export const BarcodeScanner = () => {
   const scannerRef = useRef<HTMLDivElement>();
   const [scannerReady, setScannerReady] = useState<boolean>(false);
   const [torchAvailable, setTorchAvailable] = useState<boolean>(false);
-  const [avgErrorRate, setAvgErrorRate] = useState<number | undefined>(
-    undefined
-  );
 
   const handleFlashToggle = () => {
     setIsFlashOn((flashWasOn) => {
@@ -105,7 +102,7 @@ export const BarcodeScanner = () => {
         },
         (err) => {
           if (err) {
-            console.error(err);
+            console.error("Could not initialize barcode scanner:", err);
             return;
           }
           Quagga.start();

--- a/src/mobile/feature-saving/components/MobileSavingPage.tsx
+++ b/src/mobile/feature-saving/components/MobileSavingPage.tsx
@@ -49,8 +49,6 @@ export const MobileSavingPage = () => {
   const activityRef = useRef<ElementRef<typeof Typography>>(null);
   const theme = useTheme();
 
-  console.log({ selectedActivity });
-
   const {
     data: passHoldersData,
     isError: isPassholdersError,

--- a/src/mobile/feature-saving/components/MobileSavingPage.tsx
+++ b/src/mobile/feature-saving/components/MobileSavingPage.tsx
@@ -31,13 +31,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPenToSquare } from "@fortawesome/free-solid-svg-icons";
 import { useActivity } from "@/mobile/feature-activities/context/useActivity";
-import React, {
-  ElementRef,
-  MutableRefObject,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import React, { ElementRef, useEffect, useRef, useState } from "react";
 import { ManualCardInput } from "@/mobile/feature-identification";
 import { formatUitpasNumber } from "@/shared/lib/utils/stringUtils";
 import { usePostCheckins } from "@/shared/lib/dataAccess/uitpas/generated/checkins/checkins";

--- a/src/mobile/feature-saving/components/MobileSavingPage.tsx
+++ b/src/mobile/feature-saving/components/MobileSavingPage.tsx
@@ -49,6 +49,8 @@ export const MobileSavingPage = () => {
   const activityRef = useRef<ElementRef<typeof Typography>>(null);
   const theme = useTheme();
 
+  console.log({ selectedActivity });
+
   const {
     data: passHoldersData,
     isError: isPassholdersError,
@@ -95,7 +97,7 @@ export const MobileSavingPage = () => {
   };
 
   const handleTicketSaleMutation = (tariffId: string, regularPrice: number) => {
-    if (!passHoldersData?.data?.member) return;
+    if (!passHoldersData?.data?.member || !selectedActivity) return;
 
     postTicketSale({
       data: Array.of({
@@ -135,12 +137,7 @@ export const MobileSavingPage = () => {
     selectedActivity,
   ]);
 
-  if (
-    isPassholdersLoading ||
-    isCheckinLoading ||
-    isTicketSaleLoading ||
-    !selectedActivity
-  )
+  if (isPassholdersLoading || isCheckinLoading || isTicketSaleLoading)
     return (
       <MobileNavBar>
         <UitpasLoading />
@@ -250,10 +247,16 @@ export const MobileSavingPage = () => {
         )}
 
         <Stack rowGap="10px" sx={{ marginTop: "-10px" }}>
-          <OutlinedButton onClick={handleChooseTariffClick}>
+          <OutlinedButton
+            onClick={handleChooseTariffClick}
+            disabled={selectedActivity === null}
+          >
             {t("saving.mobile.chooseTariffBtn")}
           </OutlinedButton>
-          <OutlinedButton onClick={() => console.log("TODO")}>
+          <OutlinedButton
+            onClick={() => console.log("TODO")}
+            disabled={selectedActivity === null}
+          >
             {t("saving.mobile.tradeBenefitBtn")}
           </OutlinedButton>
         </Stack>
@@ -274,7 +277,8 @@ export const MobileSavingPage = () => {
         </Typography>
 
         <ManualCardInput resetSavedPoints={handleSavedPointsReset} />
-        {selectedActivity["@id"] &&
+        {selectedActivity &&
+          selectedActivity["@id"] &&
           passHoldersData?.data?.member &&
           activityRef.current && (
             <TariffDrawer

--- a/src/mobile/feature-saving/components/Tariff.tsx
+++ b/src/mobile/feature-saving/components/Tariff.tsx
@@ -36,13 +36,15 @@ export const Tariff = ({
   const LANG_KEY = i18n.language as keyof EventName;
 
   const data = useQueries({
-    queries: priceInfo.map((tariff) =>
-      getGetTariffsQueryOptions({
+    queries: priceInfo.map((tariff) => ({
+      ...getGetTariffsQueryOptions({
         eventId: getUuid(eventId)!,
         regularPrice: tariff.price,
         uitpasNumber,
-      })
-    ),
+      }),
+      cacheTime: 0,
+      staleTime: 0,
+    })),
   }).map((res) => res.data?.data);
 
   const socialTariffs = [] as SortedType[];

--- a/src/mobile/feature-saving/components/Tariff.tsx
+++ b/src/mobile/feature-saving/components/Tariff.tsx
@@ -17,7 +17,6 @@ type TariffProps = {
   uitpasNumber: string;
   priceInfo: EventPriceInfo;
   ticketSaleMutation: (tariffId: string, regularPrice: number) => void;
-  onDrawerClose: () => void;
 };
 
 type SortedType = {
@@ -32,7 +31,6 @@ export const Tariff = ({
   eventId,
   priceInfo,
   ticketSaleMutation,
-  onDrawerClose,
 }: TariffProps) => {
   const { t, i18n } = useTranslation();
   const LANG_KEY = i18n.language as keyof EventName;
@@ -53,19 +51,17 @@ export const Tariff = ({
 
   priceInfo.forEach((priceInfo, index) => {
     const tariff = data[index];
-    const available = tariff?.available || [];
 
-    if (!available.length) {
-      if (tariff) {
-        invalidTariffs.push({
-          name: priceInfo.name,
-          price: priceInfo.price,
-          tariff: undefined,
-          tariffMessage: tariff.endUserMessage?.[LANG_KEY],
-        });
-      }
+    if (tariff?.available?.findIndex((t) => t.type === "SOCIALTARIFF") === -1) {
+      socialTariffs.push({
+        name: priceInfo.name,
+        price: priceInfo.price,
+        tariff: undefined,
+        tariffMessage: tariff.endUserMessage?.[LANG_KEY],
+      });
     }
-    available.forEach((tariff) => {
+
+    tariff?.available?.forEach((tariff, i) => {
       const item = {
         name: priceInfo.name,
         price: priceInfo.price,
@@ -100,7 +96,6 @@ export const Tariff = ({
           tariffMessage={tariff.tariffMessage}
           tariffPrice={tariff.tariff?.price}
           ticketSaleMutation={ticketSaleMutation}
-          onDrawerClose={onDrawerClose}
         />
       ))}
     </>

--- a/src/mobile/feature-saving/components/TariffCard.tsx
+++ b/src/mobile/feature-saving/components/TariffCard.tsx
@@ -60,7 +60,7 @@ export const TariffCard = ({
               {`€ ${tariffPrice}`}
             </Typography>
           </Box>
-          {tariffType === "Coupon" && tariffPrice && (
+          {tariffType === "Coupon" && tariffPrice !== undefined && (
             <Typography
               variant="body2"
               sx={{ color: theme.palette.neutral[500], fontWeight: 500 }}
@@ -90,7 +90,7 @@ export const TariffCard = ({
           <Typography variant="body2">{tariffMessage}</Typography>
         </Box>
       )}
-      {tariffPrice ? (
+      {tariffPrice !== undefined ? (
         <Button
           onClick={handleApplyTariffClick}
           sx={{

--- a/src/mobile/feature-saving/components/TariffCard.tsx
+++ b/src/mobile/feature-saving/components/TariffCard.tsx
@@ -10,7 +10,6 @@ type TariffCardProps = {
   tariffPrice?: number;
   tariffMessage?: string;
   ticketSaleMutation: (tariffId: string, regularPrice: number) => void;
-  onDrawerClose: () => void;
 };
 
 export const TariffCard = ({
@@ -21,7 +20,6 @@ export const TariffCard = ({
   tariffPrice,
   tariffMessage,
   ticketSaleMutation,
-  onDrawerClose,
 }: TariffCardProps) => {
   const { t } = useTranslation();
   const theme = useTheme();
@@ -34,7 +32,6 @@ export const TariffCard = ({
     if (!tariffId) return;
 
     ticketSaleMutation(tariffId, regularPrice);
-    onDrawerClose();
   };
 
   return (
@@ -72,7 +69,9 @@ export const TariffCard = ({
                 discount:
                   tariffPrice === 0
                     ? "100"
-                    : Math.round(100 * (tariffPrice / regularPrice)),
+                    : Math.round(
+                        100 * ((regularPrice - tariffPrice) / regularPrice)
+                      ),
               })}
             </Typography>
           )}

--- a/src/mobile/feature-saving/components/TariffDrawer.tsx
+++ b/src/mobile/feature-saving/components/TariffDrawer.tsx
@@ -34,10 +34,16 @@ export const TariffDrawer = ({
 }: TariffModalProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
-  const { data } = useEventGet(getUuid(eventId) ?? "");
+  const { data, refetch } = useEventGet(getUuid(eventId) ?? "");
 
   const handleClose = () => {
     setIsOpen(false);
+  };
+
+  const handleTicketSaleMutation = (tariffId: string, regularPrice: number) => {
+    ticketSaleMutation(tariffId, regularPrice);
+    refetch();
+    handleClose();
   };
 
   return (
@@ -107,8 +113,7 @@ export const TariffDrawer = ({
             eventId={eventId}
             uitpasNumber={uitpasNumber}
             priceInfo={data?.data.priceInfo}
-            ticketSaleMutation={ticketSaleMutation}
-            onDrawerClose={handleClose}
+            ticketSaleMutation={handleTicketSaleMutation}
           />
         ) : null}
       </Stack>

--- a/src/mobile/layouts/navbar/MobileNavBar.tsx
+++ b/src/mobile/layouts/navbar/MobileNavBar.tsx
@@ -8,16 +8,13 @@ import Image from "next/image";
 import { Settings } from "@mui/icons-material";
 import { Typography } from "@/mobile/lib/ui";
 import Link from "next/link";
-import { useActivity } from "@/mobile/feature-activities/context/useActivity";
 
 export const MobileNavBar = ({ children }: PropsWithChildren) => {
   const { setLastCounterUsed, setActiveCounter, activeCounter } = useCounter();
-  const { setSelectedActivity } = useActivity();
 
   const handleCurrentCounterClick = () => {
     setLastCounterUsed(activeCounter);
     setActiveCounter(null);
-    setSelectedActivity(null);
   };
 
   return (


### PR DESCRIPTION
### Added
The following mobile pages were added:

- Starting page & signin
- Counter selection page:
    - Separate page for when no counters are associated with the account
    - Placeholder page with a list of contacts
    - Counter select page with search input & last used counter
- Event selection page with search input & infinite scroll
- Passholder identification page:
    - Scanning barcode using your device's camera(s)
    - Manual card number input
    - Switching previously chosen event
- Point savings page:
    - Automatically save points upon correct scan/input of a card
    - Display of points
    - Display of social tariff status
    - Selecting a tariff/coupon via drawer

### Changed

### Removed

### Fixed
- Firefox not working with the barcode scanner (flashlight is not supported in firefox)
- Switching counter does not clear selected event
- Barcode scanner performs slow & sometimes scans show up with errors 
- Event selection screen containing duplicates in the infinite scroll list
- Pages containing a vertical scrollbar when it shouldn't
---
Tickets: [#UPS-4937](https://jira.publiq.be/browse/UPS-4937) [#UPS-4938](https://jira.publiq.be/browse/UPS-4938) [#UPS-4939](https://jira.publiq.be/browse/UPS-4939) [#UPS-4941](https://jira.publiq.be/browse/UPS-4941) [#UPS-4949](https://jira.publiq.be/browse/UPS-4949) [#UPS-5009](https://jira.publiq.be/browse/UPS-5009) [#UPS-5015](https://jira.publiq.be/browse/UPS-5015) [#UPS-5027](https://jira.publiq.be/browse/UPS-5027) [#UPS-5028](https://jira.publiq.be/browse/UPS-5028) [#UPS-5054](https://jira.publiq.be/browse/UPS-5054) [#UPS-5055](https://jira.publiq.be/browse/UPS-5055) 