### PR TITLE
refactor: minor code changes

### DIFF
--- a/src/mobile/feature-activities/components/ActivitiesPage.tsx
+++ b/src/mobile/feature-activities/components/ActivitiesPage.tsx
@@ -144,7 +144,7 @@ export const ActivitiesPage = () => {
           <Link
             color="primary"
             href="/mobile/identification"
-            onClick={() => setSelectedActivity(null)}
+            onClick={() => setSelectedActivity(undefined)}
           >
             {t("activities.mobile.continueNoActivity")}
           </Link>

--- a/src/mobile/feature-activities/components/ActivitiesPicker.tsx
+++ b/src/mobile/feature-activities/components/ActivitiesPicker.tsx
@@ -10,10 +10,10 @@ import {
   useRef,
   useState,
 } from "react";
-import { useTranslation } from "@/shared/lib/i18n/client";
 import { Typography } from "@/mobile/lib/ui";
 import { useSearchQuery } from "@/shared/lib/utils/hooks/useSearchQuery";
 import { useActivity } from "@/mobile/feature-activities/context/useActivity";
+import { useTranslation } from "@/shared/lib/utils/hooks/useTranslation";
 
 type ActivitiesPickerProps = {
   isInitialLoading: boolean;
@@ -38,7 +38,7 @@ export const ActivitiesPicker = ({
   setScrollPosition,
   isFetching,
 }: ActivitiesPickerProps) => {
-  const { t, i18n } = useTranslation();
+  const { t, LANG_KEY } = useTranslation();
   const scrollRef = useRef<HTMLDivElement>(null);
   const { searchQuery } = useSearchQuery();
   const { setSelectedActivity } = useActivity();
@@ -53,8 +53,6 @@ export const ActivitiesPicker = ({
       });
     }
   }, [data.member]);
-
-  const LANG_KEY = i18n.language as keyof Search.EventName;
 
   useEffect(() => {
     if (totalFetchedItems === 0) return;

--- a/src/mobile/feature-activities/context/ActivityContext.ts
+++ b/src/mobile/feature-activities/context/ActivityContext.ts
@@ -5,7 +5,7 @@ import { Search } from "@/shared/lib/dataAccess";
 
 // undefined: user has chosen to continue without selecting an activity
 // null: user hasn't selected an activity yet
-export type Activity = Search.EventAllOf | null;
+export type Activity = Search.EventAllOf | null | undefined;
 
 export const ActivityContext = createContext<{
   selectedActivity: Activity;

--- a/src/mobile/feature-identification/components/IdentificationPage.tsx
+++ b/src/mobile/feature-identification/components/IdentificationPage.tsx
@@ -1,36 +1,28 @@
 import { MobileNavBar } from "@/mobile/layouts";
 import {
+  ActivitySwitcher,
   LoadingButton,
   MobileContentStack,
   UitpasLoading,
 } from "@/mobile/lib/ui";
-import { useTranslation } from "@/shared/lib/i18n/client";
-import { Box, IconButton, Typography } from "@mui/material";
+import { Typography } from "@mui/material";
 import { useActivity } from "@/mobile/feature-activities/context/useActivity";
-import { Search } from "@/shared/lib/dataAccess";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPenToSquare } from "@fortawesome/free-solid-svg-icons";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { ManualCardInput } from "@/mobile/feature-identification/components/ManualCardInput";
+import { useTranslation } from "@/shared/lib/utils/hooks";
 
 export const IdentificationPage = () => {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const router = useRouter();
-  const { selectedActivity, setSelectedActivity } = useActivity();
+  const { selectedActivity } = useActivity();
   const [isNavigating, setIsNavigating] = useState<boolean>(false);
-
-  const LANG_KEY = i18n.language as keyof Search.EventName;
 
   useEffect(() => {
     if (selectedActivity === null) {
       router.push("/mobile/activities");
     }
   }, [selectedActivity]);
-
-  const handleChangeActivityClick = () => {
-    setSelectedActivity(null);
-  };
 
   const handleScanBarcodeClick = () => {
     router.push("/mobile/identification/scan?firstCardEntry=true");
@@ -51,32 +43,7 @@ export const IdentificationPage = () => {
         <Typography variant="h1">
           {t("identification.mobile.chosenActivity")}
         </Typography>
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-          }}
-        >
-          <Typography
-            variant="h1"
-            sx={(theme) => ({ color: theme.palette.neutral[900] })}
-          >
-            {selectedActivity
-              ? selectedActivity.name[LANG_KEY]
-              : t("identification.mobile.noActivity")}
-          </Typography>
-          <IconButton
-            disableRipple={true}
-            onClick={handleChangeActivityClick}
-            sx={(theme) => ({
-              color: theme.palette.neutral[900],
-              fontSize: 32,
-            })}
-          >
-            <FontAwesomeIcon icon={faPenToSquare} />
-          </IconButton>
-        </Box>
+        <ActivitySwitcher />
 
         <Typography variant="h1" sx={{ mt: 2 }}>
           {t("identification.mobile.identifyPassHolder")}

--- a/src/mobile/feature-saving/components/MobileSavingPage.tsx
+++ b/src/mobile/feature-saving/components/MobileSavingPage.tsx
@@ -211,14 +211,12 @@ export const MobileSavingPage = () => {
               </Alert>
             ) : (
               <Alert
-                type={isCheckinError || !selectedActivity ? "error" : "success"}
+                type={isCheckinError ? "error" : "success"}
                 newAlert={!firstCardEntry}
               >
                 {isCheckinError
                   ? checkinError?.response?.data.endUserMessage &&
                     checkinError.response.data.endUserMessage[LANG_KEY]
-                  : !selectedActivity
-                  ? t("saving.mobile.pointNoActivity")
                   : t("saving.mobile.pointSaved")}
               </Alert>
             )}

--- a/src/mobile/feature-saving/components/MobileSavingPage.tsx
+++ b/src/mobile/feature-saving/components/MobileSavingPage.tsx
@@ -1,15 +1,14 @@
 "use client";
 
-import { useTranslation } from "@/shared/lib/i18n/client";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   type TicketSale,
   useGetPassholders,
   usePostTicketSales,
 } from "@/shared/lib/dataAccess";
-import { EventName } from "@/shared/lib/dataAccess/search/generated/model";
 import { MobileNavBar } from "@/mobile/layouts";
 import {
+  ActivitySwitcher,
   Alert,
   Button,
   MobileContentStack,
@@ -21,30 +20,23 @@ import {
   OpportunityState,
   TariffDrawer,
 } from "@/mobile/feature-saving";
-import {
-  IconButton,
-  Stack,
-  Typography,
-  Divider,
-  useTheme,
-} from "@mui/material";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPenToSquare } from "@fortawesome/free-solid-svg-icons";
+import { Stack, Typography, Divider, useTheme } from "@mui/material";
 import { useActivity } from "@/mobile/feature-activities/context/useActivity";
 import React, { ElementRef, useEffect, useRef, useState } from "react";
 import { ManualCardInput } from "@/mobile/feature-identification";
 import { formatUitpasNumber } from "@/shared/lib/utils/stringUtils";
 import { usePostCheckins } from "@/shared/lib/dataAccess/uitpas/generated/checkins/checkins";
 import { getUuid } from "@/shared/lib/utils";
+import { useTranslation } from "@/shared/lib/utils/hooks";
 
 export const MobileSavingPage = () => {
-  const { t, i18n } = useTranslation();
+  const { t, LANG_KEY } = useTranslation();
   const router = useRouter();
   const params = useSearchParams();
   const theme = useTheme();
   const uitpasNumber = params.get("uitpas");
   const inszNumber = params.get("insz");
-  const { selectedActivity, setSelectedActivity } = useActivity();
+  const { selectedActivity } = useActivity();
   const [showTariffModal, setShowTariffModal] = useState<boolean>(false);
   const activityRef = useRef<ElementRef<typeof Typography>>(null);
   const [prevUitpasNumber, setPrevUitpasNumber] = useState<string>("");
@@ -88,13 +80,6 @@ export const MobileSavingPage = () => {
       },
     },
   });
-
-  const LANG_KEY = i18n.language as keyof EventName;
-
-  const handleChangeActivityClick = () => {
-    setSelectedActivity(null);
-    router.push("/mobile/activities");
-  };
 
   const handleNextScanClick = () => {
     router.push("/mobile/identification/scan");
@@ -171,33 +156,7 @@ export const MobileSavingPage = () => {
         <Typography variant="h1">
           {t("saving.mobile.chosenActivity")}
         </Typography>
-        <Stack
-          sx={{
-            flexDirection: "row",
-            alignItems: "center",
-            justifyContent: "space-between",
-          }}
-        >
-          <Typography
-            ref={activityRef}
-            variant="h1"
-            sx={{ color: theme.palette.neutral[900] }}
-          >
-            {selectedActivity
-              ? selectedActivity.name[LANG_KEY]
-              : t("saving.mobile.noActivity")}
-          </Typography>
-          <IconButton
-            disableRipple
-            onClick={handleChangeActivityClick}
-            sx={{
-              color: theme.palette.neutral[900],
-              fontSize: 32,
-            }}
-          >
-            <FontAwesomeIcon icon={faPenToSquare} />
-          </IconButton>
-        </Stack>
+        <ActivitySwitcher />
 
         {passHoldersData?.data.member?.[0] && (
           <Stack sx={{ rowGap: "10px" }}>

--- a/src/mobile/feature-saving/components/MobileSavingPage.tsx
+++ b/src/mobile/feature-saving/components/MobileSavingPage.tsx
@@ -211,12 +211,14 @@ export const MobileSavingPage = () => {
               </Alert>
             ) : (
               <Alert
-                type={isCheckinError ? "error" : "success"}
+                type={isCheckinError || !selectedActivity ? "error" : "success"}
                 newAlert={!firstCardEntry}
               >
                 {isCheckinError
                   ? checkinError?.response?.data.endUserMessage &&
                     checkinError.response.data.endUserMessage[LANG_KEY]
+                  : !selectedActivity
+                  ? t("saving.mobile.pointNoActivity")
                   : t("saving.mobile.pointSaved")}
               </Alert>
             )}

--- a/src/mobile/feature-saving/components/OpportunityStateCard.tsx
+++ b/src/mobile/feature-saving/components/OpportunityStateCard.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, PropsWithChildren, useState } from "react";
+import { PropsWithChildren, useState } from "react";
 import { Box, BoxProps, IconButton, useTheme } from "@mui/material";
 import { useTranslation } from "@/shared/lib/i18n/client";
 import { ExpandMore, ExpandLess } from "@mui/icons-material";
@@ -32,9 +32,7 @@ export const OpportunityStateCard = ({
   return (
     <Box
       sx={{
-        "&:hover": {
-          cursor: "pointer",
-        },
+        cursor: "pointer",
         display: "flex",
         flexDirection: "column",
         borderRadius: "8px",
@@ -48,8 +46,8 @@ export const OpportunityStateCard = ({
       onClick={handleClick}
       {...props}
     >
-      <div
-        style={{
+      <Box
+        sx={{
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
@@ -71,7 +69,7 @@ export const OpportunityStateCard = ({
         >
           {open ? <ExpandLess /> : <ExpandMore />}
         </IconButton>
-      </div>
+      </Box>
       {open && <>{props.children}</>}
     </Box>
   );

--- a/src/mobile/feature-saving/components/Tariff.tsx
+++ b/src/mobile/feature-saving/components/Tariff.tsx
@@ -3,16 +3,15 @@ import {
   TariffAvailibility,
 } from "@/shared/lib/dataAccess";
 import { getUuid } from "@/shared/lib/utils";
-import { useTranslation } from "@/shared/lib/i18n/client";
 import { useQueries } from "@tanstack/react-query";
 import {
   CommonName,
   EventPriceInfo,
 } from "@/lib/dataAccess/entry/generated/model";
-import { EventName } from "@/shared/lib/dataAccess/search/generated/model";
 import { TariffCard } from "@/mobile/feature-saving";
 import { CircularProgress, Typography, useTheme } from "@mui/material";
 import { useEffect, useState } from "react";
+import { useTranslation } from "@/shared/lib/utils/hooks";
 
 type TariffProps = {
   name?: string;
@@ -36,9 +35,8 @@ export const Tariff = ({
   priceInfo,
   ticketSaleMutation,
 }: TariffProps) => {
-  const { t, i18n } = useTranslation();
+  const { t, LANG_KEY } = useTranslation();
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const LANG_KEY = i18n.language as keyof EventName;
   const theme = useTheme();
 
   const priceInfoFiltered = priceInfo.filter((price) => price.price !== 0);

--- a/src/mobile/lib/ui/index.ts
+++ b/src/mobile/lib/ui/index.ts
@@ -10,3 +10,4 @@ export * from "./uitpas/UitpasLoading";
 export * from "./uitpas/MobileContentStack";
 export * from "./uitpas/Textfield";
 export * from "./uitpas/Alert";
+export * from "./uitpas/ActivitySwitcher";

--- a/src/mobile/lib/ui/uitpas/ActivitySwitcher.tsx
+++ b/src/mobile/lib/ui/uitpas/ActivitySwitcher.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useActivity } from "@/mobile/feature-activities/context/useActivity";
+import { useTranslation } from "@/shared/lib/utils/hooks/useTranslation";
+import { faPenToSquare } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Box, Typography, IconButton, useTheme } from "@mui/material";
+import { useRouter } from "next/navigation";
+
+export const ActivitySwitcher = () => {
+  const { t, LANG_KEY } = useTranslation();
+  const { selectedActivity, setSelectedActivity } = useActivity();
+  const router = useRouter();
+  const theme = useTheme();
+
+  const handleChangeActivityClick = () => {
+    setSelectedActivity(null);
+    router.push("/mobile/activities");
+  };
+
+  return (
+    <Box
+      onClick={handleChangeActivityClick}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        cursor: "pointer",
+      }}
+    >
+      <Typography variant="h1" sx={{ color: theme.palette.neutral[900] }}>
+        {selectedActivity
+          ? selectedActivity.name[LANG_KEY]
+          : t("identification.mobile.noActivity")}
+      </Typography>
+      <IconButton
+        disableRipple={true}
+        sx={{
+          color: theme.palette.neutral[900],
+          fontSize: 32,
+        }}
+      >
+        <FontAwesomeIcon icon={faPenToSquare} />
+      </IconButton>
+    </Box>
+  );
+};

--- a/src/mobile/lib/ui/uitpas/ActivitySwitcher.tsx
+++ b/src/mobile/lib/ui/uitpas/ActivitySwitcher.tsx
@@ -26,6 +26,7 @@ export const ActivitySwitcher = () => {
         alignItems: "center",
         justifyContent: "space-between",
         cursor: "pointer",
+        mt: "-20px",
       }}
     >
       <Typography variant="h1" sx={{ color: theme.palette.neutral[900] }}>

--- a/src/shared/lib/i18n/locales/nl/common.json
+++ b/src/shared/lib/i18n/locales/nl/common.json
@@ -175,7 +175,6 @@
       "passholder": "Pashouder",
       "namePointsTxt": "{{firstName}} {{lastName}} ({{points}} punten)",
       "pointSaved": "Punt gespaard",
-      "pointNoActivity": "Er kan geen punt gespaard worden zonder activiteit",
       "failure": {
         "tryAgainBtn": "Probeer opnieuw",
         "inputCardNoBtn": "Een kaartnummer invullen"

--- a/src/shared/lib/i18n/locales/nl/common.json
+++ b/src/shared/lib/i18n/locales/nl/common.json
@@ -181,7 +181,7 @@
       },
       "chooseTariffBtn": "Kies tarief",
       "tradeBenefitBtn": "Voordeel omruilen",
-      "scanNextBtn": "Volgende UitPAS scannen",
+      "scanNextBtn": "Volgende UiTPAS scannen",
       "or": "Of",
       "opportunityState": {
         "active": {

--- a/src/shared/lib/i18n/locales/nl/common.json
+++ b/src/shared/lib/i18n/locales/nl/common.json
@@ -175,6 +175,7 @@
       "passholder": "Pashouder",
       "namePointsTxt": "{{firstName}} {{lastName}} ({{points}} punten)",
       "pointSaved": "Punt gespaard",
+      "pointNoActivity": "Er kan geen punt gespaard worden zonder activiteit",
       "failure": {
         "tryAgainBtn": "Probeer opnieuw",
         "inputCardNoBtn": "Een kaartnummer invullen"

--- a/src/shared/lib/utils/hooks/index.ts
+++ b/src/shared/lib/utils/hooks/index.ts
@@ -3,3 +3,4 @@ export * from "./useIsBlacklisted";
 export * from "./useMenu";
 export * from "./useIsPreviousRender";
 export * from "./useDetectMobile";
+export * from "./useTranslation";

--- a/src/shared/lib/utils/hooks/useTranslation.ts
+++ b/src/shared/lib/utils/hooks/useTranslation.ts
@@ -1,0 +1,10 @@
+"use client";
+
+import { useTranslation as useNextTranslation } from "@/shared/lib/i18n/client";
+import { EventName } from "../../dataAccess/search/generated/model";
+
+export const useTranslation = () => {
+  const { t, i18n } = useNextTranslation();
+
+  return { t, i18n, LANG_KEY: i18n.language as keyof EventName };
+};

--- a/src/web/feature-activities/components/ActivitiesPage.tsx
+++ b/src/web/feature-activities/components/ActivitiesPage.tsx
@@ -11,16 +11,10 @@ import {
   PageWithSideBarNew,
   Typography,
 } from "@/web/lib/ui";
-import { useTranslation } from "@/shared/lib/i18n/client";
 import { RangeMenu } from "./RangeMenu";
 import { SearchInput } from "./SearchInput";
-
 import dayjs from "dayjs";
-import {
-  EventAllOf,
-  EventName,
-} from "@/shared/lib/dataAccess/search/generated/model";
-import { useRouter } from "next/navigation";
+import { EventAllOf } from "@/shared/lib/dataAccess/search/generated/model";
 import {
   ActionLink,
   StyledActionsStack,
@@ -46,9 +40,10 @@ import { usePaginationQuery } from "@/shared/lib/utils/hooks/usePaginationQuery"
 import { ActionButton } from "@/web/lib/ui/uitpas/ActionButton";
 import { useRangeQuery } from "@/shared/lib/utils/hooks/useRangeQuery";
 import { useSearchQuery } from "@/shared/lib/utils/hooks/useSearchQuery";
+import { useTranslation } from "@/shared/lib/utils/hooks";
 
 export const ActivitiesPage = () => {
-  const { t, i18n } = useTranslation();
+  const { t, LANG_KEY } = useTranslation();
   const { activeCounter: counter } = useCounter();
 
   const { fetchLimit, offset } = usePaginationQuery();
@@ -72,8 +67,6 @@ export const ActivitiesPage = () => {
     availableFrom: "*",
     availableTo: "*",
   });
-
-  const LANG_KEY = i18n.language as keyof EventName;
 
   return (
     <>


### PR DESCRIPTION
### Added
- useTranslation hook, which is a wrapper for i18next, but exports an extra LANG_KEY prop which is used in many places
- Error message when we're on the savings page without an activity, stating that points could not be saved without an activity
### Changed
- Typo in translation: "Volgende UitPAS scannen" -> "Volgende UiTPAS scannen"
- Extracted switching activity to separate component for reusability
- Changed the onClick event to target the entire activity switcher instead of the icon only
- Reduced space between title and activity switcher
### Removed

### Fixed
- Clicking on "Verder gaan zonder activiteit" should work now
---
Ticket: [#UPS-5078](https://jira.publiq.be/browse/UPS-5078)
