### PR TITLE
fix: react query & polyfill support for older devices

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -27,6 +27,7 @@ const nextConfig = {
       ],
     },
   },
+  transpilePackages: ["@tanstack/query-core", "@tanstack/react-query"],
 };
 
 module.exports = nextConfig;

--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -6,6 +6,7 @@ import { MobileProviders } from "@/app/MobileProviders";
 import { WebProviders } from "@/app/WebProviders";
 import { openSansFont } from "@/web/lib/ui";
 import { poppinsFont } from "@/mobile/lib/ui";
+import "@/shared/lib/utils/polyfills";
 
 export function Providers({ children }: PropsWithChildren) {
   const device = useDetectMobile();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,6 @@ import { Metadata, Viewport } from "next";
 import { Providers } from "@/app/Providers";
 import { palette } from "@/mobile/lib/ui";
 import { ConfigProvider } from "@/shared/feature-config/context/ConfigProvider";
-import "@/shared/lib/utils/polyfills";
 
 const APP_NAME = "UiTPAS Beheer";
 const APP_DEFAULT_TITLE = "UiTPAS Beheer";


### PR DESCRIPTION
### Added

### Changed

### Removed

### Fixed
- toSorted polyfill should be working as intended now.
- React query should work on older iOS devices.
---
Ticket: [#UPS-5152](https://jira.publiq.be/browse/UPS-5152)
