### PR TITLE
fix: useCamera hook not finding a back camera

### DIFF
--- a/src/shared/lib/utils/hooks/useCamera.ts
+++ b/src/shared/lib/utils/hooks/useCamera.ts
@@ -75,8 +75,9 @@ export const useCamera = ({
   useEffect(() => {
     setBrowser(uaParser(navigator.userAgent).browser.name);
     setBrowserHasSupport(
-      navigator.mediaDevices &&
-        typeof navigator.mediaDevices.getUserMedia === "function" &&
+      ((navigator.mediaDevices &&
+        typeof navigator.mediaDevices.getUserMedia === "function") ??
+        false) &&
         browser !== "Opera"
     );
     if (!initializeCamera) setIsLoading(false);
@@ -189,7 +190,14 @@ export const useCamera = ({
             }
           }
 
-          if (cameraType === "back" && capabilities && !canTorch) {
+          // When looking for a back camera, it's preferable to find a device that supports torch,
+          // but if by the last attempt we still don't find such a device, we will fall back to the first back camera that is found.
+          if (
+            cameraType === "back" &&
+            capabilities &&
+            !canTorch &&
+            retryCount < MAX_RETRY_ATTEMPTS
+          ) {
             continue;
           }
 


### PR DESCRIPTION
### Added

### Changed

### Removed

### Fixed
- useCamera hook not finding any back camera with torch support -> fallback to the first back camera it finds on last probe attempt (should in theory be a non-wide camera)
---
Ticket: [#UPS-5152](https://jira.publiq.be/browse/UPS-5152)
