### PR TITLE
Improve sorting of activities

### DIFF
--- a/src/mobile/feature-activities/components/ActivitiesPage.tsx
+++ b/src/mobile/feature-activities/components/ActivitiesPage.tsx
@@ -69,7 +69,8 @@ export const ActivitiesPage = () => {
     dateFrom: dates.dateFrom,
     dateTo: dates.dateTo,
     availableFrom: "*",
-    availableTo: "*"
+    availableTo: "*",
+    sort: { availableTo: "asc" },
   });
   const [isInitialLoading, setIsInitialLoading] = useState<boolean>(true);
   const [showSearchInput, setShowSearchInput] = useState<boolean | null>(null);


### PR DESCRIPTION
### Changed
Currently the events are not sorted in the mobile version of the balie.

This change adds ?sort[availableTo]=asc
So more recent events will be above
https://docs.publiq.be/docs/uitdatabank/search-api/sorting#availableto


