### PR TITLE
UPS-5286 - Allow RewardsDrawer to render for passholders with 0 points

### DIFF
--- a/src/mobile/feature-saving/components/MobileSavingPage.tsx
+++ b/src/mobile/feature-saving/components/MobileSavingPage.tsx
@@ -337,8 +337,7 @@ export const MobileSavingPage = () => {
           )}
 
         {activityRef.current &&
-          passHoldersData?.data?.member &&
-          passHoldersData.data.member[0].points && (
+          passHoldersData?.data?.member && (
             <RewardsDrawer
               isOpen={showRewardsDrawer}
               setIsOpen={setShowRewardsDrawer}


### PR DESCRIPTION
### Summary
This PR fixes an issue where the `RewardsDrawer` component would not render for passholders with 0 points. The current logic prevented rendering if `points` was falsy, which is incorrect as there are "welcome rewards" that require 0 points. The restriction on points has been removed to ensure all pass holders can access the rewards drawer, regardless of their point balance.

### Changes
- Removed the `passHoldersData.data.member[0].points` condition from the rendering logic of `RewardsDrawer` in `MobileSavingPage`.
- This ensures the `RewardsDrawer` renders for all pass holders, including those eligible for "welcome rewards" with 0 points.

### Related Tickets
https://jira.publiq.be/browse/UPS-5286
