### PR TITLE
UPS-5286: Fix type error for passHolderPoints in RewardsDrawer

### DIFF
--- a/src/mobile/feature-saving/components/MobileSavingPage.tsx
+++ b/src/mobile/feature-saving/components/MobileSavingPage.tsx
@@ -348,7 +348,7 @@ export const MobileSavingPage = () => {
                   ? `${passHoldersData.data.member[0].firstName} ${passHoldersData.data.member[0].name}`
                   : undefined
               }
-              passHolderPoints={passHoldersData.data.member[0].points}
+              passHolderPoints={passHoldersData.data.member[0].points ?? 0}
               rewardRedemptionMutation={handleRewardRedemption}
             />
           )}


### PR DESCRIPTION
### Summary
This PR resolves a type error during the build process caused by `passHoldersData.data.member[0].points` being potentially undefined. The `passHolderPoints` prop in `RewardsDrawer` now defaults to `0` when `points` is `undefined`, ensuring the component always receives a valid `number`.

### Changes
- Updated `passHolderPoints` prop in `RewardsDrawer` to use a fallback (`?? 0`) for undefined values.

### Reason
- There are "welcome rewards" that require 0 points. To ensure the `RewardsDrawer` renders correctly and the application builds without errors, this fix was necessary.

### Tickets
https://jira.publiq.be/browse/UPS-5286
