### PR TITLE
Limit event search to next 30 days

### DIFF
--- a/src/shared/feature-events/getEventParams.ts
+++ b/src/shared/feature-events/getEventParams.ts
@@ -4,7 +4,7 @@ import { GetEventsParams } from "@/shared/lib/dataAccess/search/generated/model"
 
 export const getEventParams = (): GetEventsParams => {
   const dateFrom = dateToISODateTimeString();
-  const dateTo = dateToISODateTimeString(dayjs().add(90, "days").toDate());
+  const dateTo = dateToISODateTimeString(dayjs().add(30, "days").toDate());
 
   return {
     embed: true,


### PR DESCRIPTION
Limit the event search to the upcoming 30 days instead of 90 to make the loading of events faster.
